### PR TITLE
🐛 FIX: catch block @cli.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "password-gen-cli",
-  "version": "1.0.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "password-gen-cli",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "Generates password & copy it on clipboard",
     "main": "index.js",
     "author": {

--- a/utils/cli.js
+++ b/utils/cli.js
@@ -23,6 +23,6 @@ module.exports = async () => {
         );
     } catch (error) {
         io.write(chalk.red(` Couldn't copy password to the clipboard\n`));
-        halk.italic(`Password: ${password}`);
+        io.write(chalk.italic(`Password: ${password}`));
     }
 };


### PR DESCRIPTION
I fixed a typo `halk` which suppose to be `chalk` and made it output to the std-output.